### PR TITLE
Add command to remove files that were committed before adding to .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ $ git reset <commit>
 $ git reset --keep <commit>
 ```
 
-#####Remove files that was accidentally committed before adding it in .gitignore
+#####Remove files that were accidentally committed before they were added to .gitignore
 ```
 $ git rm -r --cached .
 $ git add .

--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ $ git reset <commit>
 ```
 $ git reset --keep <commit>
 ```
+
+#####Remove files that was accidentally committed before adding it in .gitignore
+```
+$ git rm -r --cached .
+$ git add .
+$ git commit -m "remove xyz file"
+```
 <hr>
 
 ##Git-Flow


### PR DESCRIPTION
Sometimes I accidentally commit files I didn't want to track like project specific files think .project, .settings, .iml, etc...Once they are added to the .gitignore file you still need to remove them from being tracked.  To do that:

-git rm -r --cached .
-git add .
-git commit -m "remove xyz file"
