### PR TITLE
Add reflog to cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,16 @@ $ git log --oneline <origin/master>..<remote/master> --left-right
 ```
 $ git blame <file>
 ```
+
+#####Show Reference log:
+```
+$ git reflog show 
+```
+
+#####Delete Reference log:
+```
+$ git reflog delete
+```
 <hr>
 ##Branches & Tags
 


### PR DESCRIPTION
Reference Log (reflog) is useful when we want to undo a rebase or we want to revert a change to a specific reference point.